### PR TITLE
fix: Bump CMAKE_CXX_STANDARD to 20

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.9.0)
 project(RNFSTurbo)
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 # Compile sources
 add_library(


### PR DESCRIPTION
New versions of React-Native require CXX_STANDARD at least level 20